### PR TITLE
El link y el texto linkeado no coinciden

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -153,7 +153,7 @@
 		</li>
 	      </div>
 	      <div class="item">
-		<li><strong>Tu negocio en OpenStreetMap:</strong> <a href="http://elblogdehumitos.com.ar/osm/">onosm.org</a>
+		<li><strong>Tu negocio en OpenStreetMap:</strong> <a href="http://elblogdehumitos.com.ar/osm/">onosm ES</a>
 		  <p>Agrega rápidamente tu negocio o POI favorito al
 		  mapa de OpenStreetMap. ¡Es rápido, fácil y no se
 		  necesita estar registrado!</p>


### PR DESCRIPTION
El fix intenta arreglar el hecho de que el link y el texto linkeado son de dos urls distintas (lo cual puede ser visto mal por alguna herramienta que detecte fraudes). El cambio es solo una propuesta, podés cambiarlo por otra cosa, tal vez cambiando también la url dentro del blog de humitos por algo como /en_osm
